### PR TITLE
Bugfix: Fix for showing BPF records for more than one BPFs

### DIFF
--- a/KanbanViewControl/hooks/useDataverse.ts
+++ b/KanbanViewControl/hooks/useDataverse.ts
@@ -87,14 +87,15 @@ export const useDataverse = (context: ComponentFramework.Context<IInputs>) => {
                 });
             });
             
-            if(stagesReduced[0] != undefined){
-                stagesReduced[0].columns = stagesReduced[0].columns.sort((a: any, b: any ) => a.order - b.order)
-                
-                stagesReduced[0].records = await getRecordCurrentStage(logicalName, stagesReduced[0].uniqueName, records)
-                return stagesReduced;
-            }
+            stagesReduced.forEach(async (process: any) => {
+                if(process != undefined){
+                    process.columns = process.columns.sort((a: any, b: any ) => a.order - b.order)
 
-            return []
+                    process.records = await getRecordCurrentStage(logicalName, process.uniqueName, records)
+                }
+            })
+
+            return stagesReduced;
         } catch (e) {
             return [];
         }


### PR DESCRIPTION
In the `useDataverse` hooks, the function `getBusinessProcessFlows` only fetches records for the first BPF.

Updated the code to fetch the records if there is more than one BPF.

Please review the changes.